### PR TITLE
add fib interpreter bench

### DIFF
--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -627,7 +627,7 @@ func BenchmarkEVMExecuteFibInterp(b *testing.B) {
 	)
 
 	for i := 0; i < b.N; i++ {
-		contract := vm.NewContract(common.Address{}, common.Address{}, new(uint256.Int), n*1000, nil)
+		contract := vm.NewContract(common.Address{}, common.Address{}, new(uint256.Int), n*100, nil)
 		contract.Code = GetFibCode(uint32(n))
 		_, err := evm.Interpreter().Run(contract, []byte{}, false)
 		if err != nil {


### PR DESCRIPTION
Result

```
goos: linux
goarch: amd64
pkg: github.com/QuarkChain/go-evmc/compiler
cpu: AMD Ryzen 9 5950X 16-Core Processor            
BenchmarkEVMExecuteFibWithSectionGasOptimization             632           1886520 ns/op
BenchmarkEVMExecuteFibWithGas                                178           6925691 ns/op
BenchmarkEVMExecuteFibWithoutGas                            3757            307645 ns/op
BenchmarkEVMExecuteFibInterp                                   9         113274663 ns/op
PASS
ok      github.com/QuarkChain/go-evmc/compiler  5.751s
```
which is about `113274663 / 1886520 = 60`x gain.