### PR TITLE
Use uint256 array as stack in compiled code

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -89,6 +89,7 @@ const (
 	ExecutionStackOverflow
 	ExecutionStackUnderflow
 	ExecutionInvalidJumpDest
+	ExecutionUnknown
 )
 
 func init() {

--- a/compiler/compiler_static.go
+++ b/compiler/compiler_static.go
@@ -245,7 +245,7 @@ func (c *EVMCompiler) compileInstructionStatic(instr EVMInstruction, execInst, s
 
 	// Check if it is host function
 	if c.table[instr.Opcode].execute != nil {
-		ret := c.builder.CreateCall(c.hostFuncType, c.hostFunc, []llvm.Value{execInst, llvm.ConstInt(c.ctx.Int64Type(), uint64(instr.Opcode), false), gasPtr, c.peekStackPtr(stack, stackPtr)}, "")
+		ret := c.builder.CreateCall(c.hostFuncType, c.hostFunc, []llvm.Value{execInst, llvm.ConstInt(c.ctx.Int64Type(), uint64(instr.Opcode), false), gasPtr, stackPtr}, "")
 		if c.table[instr.Opcode].diffDiff < 0 {
 			for i := 0; i < -c.table[instr.Opcode].diffDiff; i++ {
 				c.popStack(stack, stackPtr)

--- a/compiler/contract.go
+++ b/compiler/contract.go
@@ -36,6 +36,14 @@ func (c *Contract) Address() common.Address {
 	return c.address
 }
 
+// Caller returns the caller of the contract.
+//
+// Caller will recursively call caller when the contract is a delegate
+// call, including that of caller's caller.
+func (c *Contract) Caller() common.Address {
+	return c.caller
+}
+
 // UseGas attempts the use gas and subtracts it and returns true on success
 func (c *Contract) UseGas(gas uint64, logger *tracing.Hooks, reason tracing.GasChangeReason) (ok bool) {
 	if c.Gas < gas {

--- a/compiler/instructions.go
+++ b/compiler/instructions.go
@@ -1,0 +1,1006 @@
+// Copyright 2015 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package compiler
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/holiman/uint256"
+)
+
+// func opAdd(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
+// 	x, y := scope.Stack.pop(), scope.Stack.peek()
+// 	y.Add(&x, y)
+// 	return nil, nil
+// }
+
+// func opSub(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
+// 	x, y := scope.Stack.pop(), scope.Stack.peek()
+// 	y.Sub(&x, y)
+// 	return nil, nil
+// }
+
+// func opMul(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
+// 	x, y := scope.Stack.pop(), scope.Stack.peek()
+// 	y.Mul(&x, y)
+// 	return nil, nil
+// }
+
+// func opDiv(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
+// 	x, y := scope.Stack.pop(), scope.Stack.peek()
+// 	y.Div(&x, y)
+// 	return nil, nil
+// }
+
+// func opSdiv(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
+// 	x, y := scope.Stack.pop(), scope.Stack.peek()
+// 	y.SDiv(&x, y)
+// 	return nil, nil
+// }
+
+// func opMod(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
+// 	x, y := scope.Stack.pop(), scope.Stack.peek()
+// 	y.Mod(&x, y)
+// 	return nil, nil
+// }
+
+// func opSmod(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
+// 	x, y := scope.Stack.pop(), scope.Stack.peek()
+// 	y.SMod(&x, y)
+// 	return nil, nil
+// }
+
+// func opExp(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
+// 	base, exponent := scope.Stack.pop(), scope.Stack.peek()
+// 	exponent.Exp(&base, exponent)
+// 	return nil, nil
+// }
+
+// func opSignExtend(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
+// 	back, num := scope.Stack.pop(), scope.Stack.peek()
+// 	num.ExtendSign(num, &back)
+// 	return nil, nil
+// }
+
+// func opNot(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
+// 	x := scope.Stack.peek()
+// 	x.Not(x)
+// 	return nil, nil
+// }
+
+// func opLt(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
+// 	x, y := scope.Stack.pop(), scope.Stack.peek()
+// 	if x.Lt(y) {
+// 		y.SetOne()
+// 	} else {
+// 		y.Clear()
+// 	}
+// 	return nil, nil
+// }
+
+// func opGt(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
+// 	x, y := scope.Stack.pop(), scope.Stack.peek()
+// 	if x.Gt(y) {
+// 		y.SetOne()
+// 	} else {
+// 		y.Clear()
+// 	}
+// 	return nil, nil
+// }
+
+// func opSlt(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
+// 	x, y := scope.Stack.pop(), scope.Stack.peek()
+// 	if x.Slt(y) {
+// 		y.SetOne()
+// 	} else {
+// 		y.Clear()
+// 	}
+// 	return nil, nil
+// }
+
+// func opSgt(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
+// 	x, y := scope.Stack.pop(), scope.Stack.peek()
+// 	if x.Sgt(y) {
+// 		y.SetOne()
+// 	} else {
+// 		y.Clear()
+// 	}
+// 	return nil, nil
+// }
+
+// func opEq(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
+// 	x, y := scope.Stack.pop(), scope.Stack.peek()
+// 	if x.Eq(y) {
+// 		y.SetOne()
+// 	} else {
+// 		y.Clear()
+// 	}
+// 	return nil, nil
+// }
+
+// func opIszero(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
+// 	x := scope.Stack.peek()
+// 	if x.IsZero() {
+// 		x.SetOne()
+// 	} else {
+// 		x.Clear()
+// 	}
+// 	return nil, nil
+// }
+
+// func opAnd(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
+// 	x, y := scope.Stack.pop(), scope.Stack.peek()
+// 	y.And(&x, y)
+// 	return nil, nil
+// }
+
+// func opOr(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
+// 	x, y := scope.Stack.pop(), scope.Stack.peek()
+// 	y.Or(&x, y)
+// 	return nil, nil
+// }
+
+// func opXor(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
+// 	x, y := scope.Stack.pop(), scope.Stack.peek()
+// 	y.Xor(&x, y)
+// 	return nil, nil
+// }
+
+// func opByte(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
+// 	th, val := scope.Stack.pop(), scope.Stack.peek()
+// 	val.Byte(&th)
+// 	return nil, nil
+// }
+
+func opAddmod(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
+	x, y, z := scope.Stack.pop(), scope.Stack.pop(), scope.Stack.peek()
+	z.AddMod(&x, &y, z)
+	return nil, nil
+}
+
+func opMulmod(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
+	x, y, z := scope.Stack.pop(), scope.Stack.pop(), scope.Stack.peek()
+	z.MulMod(&x, &y, z)
+	return nil, nil
+}
+
+// // opSHL implements Shift Left
+// // The SHL instruction (shift left) pops 2 values from the stack, first arg1 and then arg2,
+// // and pushes on the stack arg2 shifted to the left by arg1 number of bits.
+// func opSHL(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
+// 	// Note, second operand is left in the stack; accumulate result into it, and no need to push it afterwards
+// 	shift, value := scope.Stack.pop(), scope.Stack.peek()
+// 	if shift.LtUint64(256) {
+// 		value.Lsh(value, uint(shift.Uint64()))
+// 	} else {
+// 		value.Clear()
+// 	}
+// 	return nil, nil
+// }
+
+// // opSHR implements Logical Shift Right
+// // The SHR instruction (logical shift right) pops 2 values from the stack, first arg1 and then arg2,
+// // and pushes on the stack arg2 shifted to the right by arg1 number of bits with zero fill.
+// func opSHR(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
+// 	// Note, second operand is left in the stack; accumulate result into it, and no need to push it afterwards
+// 	shift, value := scope.Stack.pop(), scope.Stack.peek()
+// 	if shift.LtUint64(256) {
+// 		value.Rsh(value, uint(shift.Uint64()))
+// 	} else {
+// 		value.Clear()
+// 	}
+// 	return nil, nil
+// }
+
+// // opSAR implements Arithmetic Shift Right
+// // The SAR instruction (arithmetic shift right) pops 2 values from the stack, first arg1 and then arg2,
+// // and pushes on the stack arg2 shifted to the right by arg1 number of bits with sign extension.
+// func opSAR(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
+// 	shift, value := scope.Stack.pop(), scope.Stack.peek()
+// 	if shift.GtUint64(256) {
+// 		if value.Sign() >= 0 {
+// 			value.Clear()
+// 		} else {
+// 			// Max negative shift: all bits set
+// 			value.SetAllOne()
+// 		}
+// 		return nil, nil
+// 	}
+// 	n := uint(shift.Uint64())
+// 	value.SRsh(value, n)
+// 	return nil, nil
+// }
+
+// func opKeccak256(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
+// 	offset, size := scope.Stack.pop(), scope.Stack.peek()
+// 	data := scope.Memory.GetPtr(offset.Uint64(), size.Uint64())
+
+// 	evm.hasher.Reset()
+// 	evm.hasher.Write(data)
+// 	evm.hasher.Read(evm.hasherBuf[:])
+
+// 	if evm.Config.EnablePreimageRecording {
+// 		evm.StateDB.AddPreimage(evm.hasherBuf, data)
+// 	}
+// 	size.SetBytes(evm.hasherBuf[:])
+// 	return nil, nil
+// }
+
+func opAddress(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
+	scope.Stack.push(new(uint256.Int).SetBytes(scope.Contract.Address().Bytes()))
+	return nil, nil
+}
+
+func opBalance(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
+	slot := scope.Stack.peek()
+	address := common.Address(slot.Bytes20())
+	slot.Set(evm.StateDB.GetBalance(address))
+	return nil, nil
+}
+
+func opOrigin(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
+	scope.Stack.push(new(uint256.Int).SetBytes(evm.Origin.Bytes()))
+	return nil, nil
+}
+
+func opCaller(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
+	scope.Stack.push(new(uint256.Int).SetBytes(scope.Contract.Caller().Bytes()))
+	return nil, nil
+}
+
+// func opCallValue(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
+// 	scope.Stack.push(scope.Contract.value)
+// 	return nil, nil
+// }
+
+// func opCallDataLoad(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
+// 	x := scope.Stack.peek()
+// 	if offset, overflow := x.Uint64WithOverflow(); !overflow {
+// 		data := getData(scope.Contract.Input, offset, 32)
+// 		x.SetBytes(data)
+// 	} else {
+// 		x.Clear()
+// 	}
+// 	return nil, nil
+// }
+
+// func opCallDataSize(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
+// 	scope.Stack.push(new(uint256.Int).SetUint64(uint64(len(scope.Contract.Input))))
+// 	return nil, nil
+// }
+
+// func opCallDataCopy(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
+// 	var (
+// 		memOffset  = scope.Stack.pop()
+// 		dataOffset = scope.Stack.pop()
+// 		length     = scope.Stack.pop()
+// 	)
+// 	dataOffset64, overflow := dataOffset.Uint64WithOverflow()
+// 	if overflow {
+// 		dataOffset64 = math.MaxUint64
+// 	}
+// 	// These values are checked for overflow during gas cost calculation
+// 	memOffset64 := memOffset.Uint64()
+// 	length64 := length.Uint64()
+// 	scope.Memory.Set(memOffset64, length64, getData(scope.Contract.Input, dataOffset64, length64))
+
+// 	return nil, nil
+// }
+
+// func opReturnDataSize(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
+// 	scope.Stack.push(new(uint256.Int).SetUint64(uint64(len(evm.returnData))))
+// 	return nil, nil
+// }
+
+// func opReturnDataCopy(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
+// 	var (
+// 		memOffset  = scope.Stack.pop()
+// 		dataOffset = scope.Stack.pop()
+// 		length     = scope.Stack.pop()
+// 	)
+
+// 	offset64, overflow := dataOffset.Uint64WithOverflow()
+// 	if overflow {
+// 		return nil, ErrReturnDataOutOfBounds
+// 	}
+// 	// we can reuse dataOffset now (aliasing it for clarity)
+// 	var end = dataOffset
+// 	end.Add(&dataOffset, &length)
+// 	end64, overflow := end.Uint64WithOverflow()
+// 	if overflow || uint64(len(evm.returnData)) < end64 {
+// 		return nil, ErrReturnDataOutOfBounds
+// 	}
+// 	scope.Memory.Set(memOffset.Uint64(), length.Uint64(), evm.returnData[offset64:end64])
+// 	return nil, nil
+// }
+
+// func opExtCodeSize(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
+// 	slot := scope.Stack.peek()
+// 	slot.SetUint64(uint64(evm.StateDB.GetCodeSize(slot.Bytes20())))
+// 	return nil, nil
+// }
+
+// func opCodeSize(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
+// 	scope.Stack.push(new(uint256.Int).SetUint64(uint64(len(scope.Contract.Code))))
+// 	return nil, nil
+// }
+
+// func opCodeCopy(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
+// 	var (
+// 		memOffset  = scope.Stack.pop()
+// 		codeOffset = scope.Stack.pop()
+// 		length     = scope.Stack.pop()
+// 	)
+// 	uint64CodeOffset, overflow := codeOffset.Uint64WithOverflow()
+// 	if overflow {
+// 		uint64CodeOffset = math.MaxUint64
+// 	}
+
+// 	codeCopy := getData(scope.Contract.Code, uint64CodeOffset, length.Uint64())
+// 	scope.Memory.Set(memOffset.Uint64(), length.Uint64(), codeCopy)
+// 	return nil, nil
+// }
+
+// func opExtCodeCopy(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
+// 	var (
+// 		stack      = scope.Stack
+// 		a          = stack.pop()
+// 		memOffset  = stack.pop()
+// 		codeOffset = stack.pop()
+// 		length     = stack.pop()
+// 	)
+// 	uint64CodeOffset, overflow := codeOffset.Uint64WithOverflow()
+// 	if overflow {
+// 		uint64CodeOffset = math.MaxUint64
+// 	}
+// 	addr := common.Address(a.Bytes20())
+// 	code := evm.StateDB.GetCode(addr)
+// 	codeCopy := getData(code, uint64CodeOffset, length.Uint64())
+// 	scope.Memory.Set(memOffset.Uint64(), length.Uint64(), codeCopy)
+
+// 	return nil, nil
+// }
+
+// // opExtCodeHash returns the code hash of a specified account.
+// // There are several cases when the function is called, while we can relay everything
+// // to `state.GetCodeHash` function to ensure the correctness.
+// //
+// //  1. Caller tries to get the code hash of a normal contract account, state
+// //     should return the relative code hash and set it as the result.
+// //
+// //  2. Caller tries to get the code hash of a non-existent account, state should
+// //     return common.Hash{} and zero will be set as the result.
+// //
+// //  3. Caller tries to get the code hash for an account without contract code, state
+// //     should return emptyCodeHash(0xc5d246...) as the result.
+// //
+// //  4. Caller tries to get the code hash of a precompiled account, the result should be
+// //     zero or emptyCodeHash.
+// //
+// // It is worth noting that in order to avoid unnecessary create and clean, all precompile
+// // accounts on mainnet have been transferred 1 wei, so the return here should be
+// // emptyCodeHash. If the precompile account is not transferred any amount on a private or
+// // customized chain, the return value will be zero.
+// //
+// //  5. Caller tries to get the code hash for an account which is marked as self-destructed
+// //     in the current transaction, the code hash of this account should be returned.
+// //
+// //  6. Caller tries to get the code hash for an account which is marked as deleted, this
+// //     account should be regarded as a non-existent account and zero should be returned.
+// func opExtCodeHash(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
+// 	slot := scope.Stack.peek()
+// 	address := common.Address(slot.Bytes20())
+// 	if evm.StateDB.Empty(address) {
+// 		slot.Clear()
+// 	} else {
+// 		slot.SetBytes(evm.StateDB.GetCodeHash(address).Bytes())
+// 	}
+// 	return nil, nil
+// }
+
+// func opGasprice(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
+// 	v, _ := uint256.FromBig(evm.GasPrice)
+// 	scope.Stack.push(v)
+// 	return nil, nil
+// }
+
+// func opBlockhash(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
+// 	num := scope.Stack.peek()
+// 	num64, overflow := num.Uint64WithOverflow()
+// 	if overflow {
+// 		num.Clear()
+// 		return nil, nil
+// 	}
+
+// 	var upper, lower uint64
+// 	upper = evm.Context.BlockNumber.Uint64()
+// 	if upper < 257 {
+// 		lower = 0
+// 	} else {
+// 		lower = upper - 256
+// 	}
+// 	if num64 >= lower && num64 < upper {
+// 		res := evm.Context.GetHash(num64)
+// 		if witness := evm.StateDB.Witness(); witness != nil {
+// 			witness.AddBlockHash(num64)
+// 		}
+// 		if tracer := evm.Config.Tracer; tracer != nil && tracer.OnBlockHashRead != nil {
+// 			tracer.OnBlockHashRead(num64, res)
+// 		}
+// 		num.SetBytes(res[:])
+// 	} else {
+// 		num.Clear()
+// 	}
+// 	return nil, nil
+// }
+
+func opCoinbase(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
+	scope.Stack.push(new(uint256.Int).SetBytes(evm.Context.Coinbase.Bytes()))
+	return nil, nil
+}
+
+// func opTimestamp(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
+// 	scope.Stack.push(new(uint256.Int).SetUint64(evm.Context.Time))
+// 	return nil, nil
+// }
+
+// func opNumber(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
+// 	v, _ := uint256.FromBig(evm.Context.BlockNumber)
+// 	scope.Stack.push(v)
+// 	return nil, nil
+// }
+
+// func opDifficulty(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
+// 	v, _ := uint256.FromBig(evm.Context.Difficulty)
+// 	scope.Stack.push(v)
+// 	return nil, nil
+// }
+
+// func opRandom(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
+// 	v := new(uint256.Int).SetBytes(evm.Context.Random.Bytes())
+// 	scope.Stack.push(v)
+// 	return nil, nil
+// }
+
+// func opGasLimit(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
+// 	scope.Stack.push(new(uint256.Int).SetUint64(evm.Context.GasLimit))
+// 	return nil, nil
+// }
+
+// func opPop(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
+// 	scope.Stack.pop()
+// 	return nil, nil
+// }
+
+func opMload(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
+	v := scope.Stack.peek()
+	offset := v.Uint64()
+	v.SetBytes(scope.Memory.GetPtr(offset, 32))
+	return nil, nil
+}
+
+func opMstore(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
+	mStart, val := scope.Stack.pop(), scope.Stack.pop()
+	scope.Memory.Set32(mStart.Uint64(), &val)
+	return nil, nil
+}
+
+func opMstore8(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
+	off, val := scope.Stack.pop(), scope.Stack.pop()
+	scope.Memory.store[off.Uint64()] = byte(val.Uint64())
+	return nil, nil
+}
+
+func opSload(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
+	loc := scope.Stack.peek()
+	hash := common.Hash(loc.Bytes32())
+	val := evm.StateDB.GetState(scope.Contract.Address(), hash)
+	loc.SetBytes(val.Bytes())
+	return nil, nil
+}
+
+func opSstore(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
+	// if evm.readOnly {
+	// 	return nil, ErrWriteProtection
+	// }
+	loc := scope.Stack.pop()
+	val := scope.Stack.pop()
+	evm.StateDB.SetState(scope.Contract.Address(), loc.Bytes32(), val.Bytes32())
+	return nil, nil
+}
+
+// func opJump(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
+// 	if evm.abort.Load() {
+// 		return nil, errStopToken
+// 	}
+// 	pos := scope.Stack.pop()
+// 	if !scope.Contract.validJumpdest(&pos) {
+// 		return nil, ErrInvalidJump
+// 	}
+// 	*pc = pos.Uint64() - 1 // pc will be increased by the interpreter loop
+// 	return nil, nil
+// }
+
+// func opJumpi(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
+// 	if evm.abort.Load() {
+// 		return nil, errStopToken
+// 	}
+// 	pos, cond := scope.Stack.pop(), scope.Stack.pop()
+// 	if !cond.IsZero() {
+// 		if !scope.Contract.validJumpdest(&pos) {
+// 			return nil, ErrInvalidJump
+// 		}
+// 		*pc = pos.Uint64() - 1 // pc will be increased by the interpreter loop
+// 	}
+// 	return nil, nil
+// }
+
+// func opJumpdest(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
+// 	return nil, nil
+// }
+
+// func opPc(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
+// 	scope.Stack.push(new(uint256.Int).SetUint64(*pc))
+// 	return nil, nil
+// }
+
+// func opMsize(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
+// 	scope.Stack.push(new(uint256.Int).SetUint64(uint64(scope.Memory.Len())))
+// 	return nil, nil
+// }
+
+// func opGas(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
+// 	scope.Stack.push(new(uint256.Int).SetUint64(scope.Contract.Gas))
+// 	return nil, nil
+// }
+
+// func opSwap1(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
+// 	scope.Stack.swap1()
+// 	return nil, nil
+// }
+
+// func opSwap2(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
+// 	scope.Stack.swap2()
+// 	return nil, nil
+// }
+
+// func opSwap3(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
+// 	scope.Stack.swap3()
+// 	return nil, nil
+// }
+
+// func opSwap4(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
+// 	scope.Stack.swap4()
+// 	return nil, nil
+// }
+
+// func opSwap5(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
+// 	scope.Stack.swap5()
+// 	return nil, nil
+// }
+
+// func opSwap6(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
+// 	scope.Stack.swap6()
+// 	return nil, nil
+// }
+
+// func opSwap7(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
+// 	scope.Stack.swap7()
+// 	return nil, nil
+// }
+
+// func opSwap8(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
+// 	scope.Stack.swap8()
+// 	return nil, nil
+// }
+
+// func opSwap9(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
+// 	scope.Stack.swap9()
+// 	return nil, nil
+// }
+
+// func opSwap10(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
+// 	scope.Stack.swap10()
+// 	return nil, nil
+// }
+
+// func opSwap11(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
+// 	scope.Stack.swap11()
+// 	return nil, nil
+// }
+
+// func opSwap12(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
+// 	scope.Stack.swap12()
+// 	return nil, nil
+// }
+
+// func opSwap13(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
+// 	scope.Stack.swap13()
+// 	return nil, nil
+// }
+
+// func opSwap14(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
+// 	scope.Stack.swap14()
+// 	return nil, nil
+// }
+
+// func opSwap15(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
+// 	scope.Stack.swap15()
+// 	return nil, nil
+// }
+
+// func opSwap16(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
+// 	scope.Stack.swap16()
+// 	return nil, nil
+// }
+
+// func opCreate(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
+// 	if evm.readOnly {
+// 		return nil, ErrWriteProtection
+// 	}
+// 	var (
+// 		value        = scope.Stack.pop()
+// 		offset, size = scope.Stack.pop(), scope.Stack.pop()
+// 		input        = scope.Memory.GetCopy(offset.Uint64(), size.Uint64())
+// 		gas          = scope.Contract.Gas
+// 	)
+// 	if evm.chainRules.IsEIP150 {
+// 		gas -= gas / 64
+// 	}
+
+// 	// reuse size int for stackvalue
+// 	stackvalue := size
+
+// 	scope.Contract.UseGas(gas, evm.Config.Tracer, tracing.GasChangeCallContractCreation)
+
+// 	res, addr, returnGas, suberr := evm.Create(scope.Contract.Address(), input, gas, &value)
+// 	// Push item on the stack based on the returned error. If the ruleset is
+// 	// homestead we must check for CodeStoreOutOfGasError (homestead only
+// 	// rule) and treat as an error, if the ruleset is frontier we must
+// 	// ignore this error and pretend the operation was successful.
+// 	if evm.chainRules.IsHomestead && suberr == ErrCodeStoreOutOfGas {
+// 		stackvalue.Clear()
+// 	} else if suberr != nil && suberr != ErrCodeStoreOutOfGas {
+// 		stackvalue.Clear()
+// 	} else {
+// 		stackvalue.SetBytes(addr.Bytes())
+// 	}
+// 	scope.Stack.push(&stackvalue)
+
+// 	scope.Contract.RefundGas(returnGas, evm.Config.Tracer, tracing.GasChangeCallLeftOverRefunded)
+
+// 	if suberr == ErrExecutionReverted {
+// 		evm.returnData = res // set REVERT data to return data buffer
+// 		return res, nil
+// 	}
+// 	evm.returnData = nil // clear dirty return data buffer
+// 	return nil, nil
+// }
+
+// func opCreate2(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
+// 	if evm.readOnly {
+// 		return nil, ErrWriteProtection
+// 	}
+// 	var (
+// 		endowment    = scope.Stack.pop()
+// 		offset, size = scope.Stack.pop(), scope.Stack.pop()
+// 		salt         = scope.Stack.pop()
+// 		input        = scope.Memory.GetCopy(offset.Uint64(), size.Uint64())
+// 		gas          = scope.Contract.Gas
+// 	)
+
+// 	// Apply EIP150
+// 	gas -= gas / 64
+// 	scope.Contract.UseGas(gas, evm.Config.Tracer, tracing.GasChangeCallContractCreation2)
+// 	// reuse size int for stackvalue
+// 	stackvalue := size
+// 	res, addr, returnGas, suberr := evm.Create2(scope.Contract.Address(), input, gas,
+// 		&endowment, &salt)
+// 	// Push item on the stack based on the returned error.
+// 	if suberr != nil {
+// 		stackvalue.Clear()
+// 	} else {
+// 		stackvalue.SetBytes(addr.Bytes())
+// 	}
+// 	scope.Stack.push(&stackvalue)
+// 	scope.Contract.RefundGas(returnGas, evm.Config.Tracer, tracing.GasChangeCallLeftOverRefunded)
+
+// 	if suberr == ErrExecutionReverted {
+// 		evm.returnData = res // set REVERT data to return data buffer
+// 		return res, nil
+// 	}
+// 	evm.returnData = nil // clear dirty return data buffer
+// 	return nil, nil
+// }
+
+// func opCall(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
+// 	stack := scope.Stack
+// 	// Pop gas. The actual gas in evm.callGasTemp.
+// 	// We can use this as a temporary value
+// 	temp := stack.pop()
+// 	gas := evm.callGasTemp
+// 	// Pop other call parameters.
+// 	addr, value, inOffset, inSize, retOffset, retSize := stack.pop(), stack.pop(), stack.pop(), stack.pop(), stack.pop(), stack.pop()
+// 	toAddr := common.Address(addr.Bytes20())
+// 	// Get the arguments from the memory.
+// 	args := scope.Memory.GetPtr(inOffset.Uint64(), inSize.Uint64())
+
+// 	if evm.readOnly && !value.IsZero() {
+// 		return nil, ErrWriteProtection
+// 	}
+// 	if !value.IsZero() {
+// 		gas += params.CallStipend
+// 	}
+// 	ret, returnGas, err := evm.Call(scope.Contract.Address(), toAddr, args, gas, &value)
+
+// 	if err != nil {
+// 		temp.Clear()
+// 	} else {
+// 		temp.SetOne()
+// 	}
+// 	stack.push(&temp)
+// 	if err == nil || err == ErrExecutionReverted {
+// 		scope.Memory.Set(retOffset.Uint64(), retSize.Uint64(), ret)
+// 	}
+
+// 	scope.Contract.RefundGas(returnGas, evm.Config.Tracer, tracing.GasChangeCallLeftOverRefunded)
+
+// 	evm.returnData = ret
+// 	return ret, nil
+// }
+
+// func opCallCode(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
+// 	// Pop gas. The actual gas is in evm.callGasTemp.
+// 	stack := scope.Stack
+// 	// We use it as a temporary value
+// 	temp := stack.pop()
+// 	gas := evm.callGasTemp
+// 	// Pop other call parameters.
+// 	addr, value, inOffset, inSize, retOffset, retSize := stack.pop(), stack.pop(), stack.pop(), stack.pop(), stack.pop(), stack.pop()
+// 	toAddr := common.Address(addr.Bytes20())
+// 	// Get arguments from the memory.
+// 	args := scope.Memory.GetPtr(inOffset.Uint64(), inSize.Uint64())
+
+// 	if !value.IsZero() {
+// 		gas += params.CallStipend
+// 	}
+
+// 	ret, returnGas, err := evm.CallCode(scope.Contract.Address(), toAddr, args, gas, &value)
+// 	if err != nil {
+// 		temp.Clear()
+// 	} else {
+// 		temp.SetOne()
+// 	}
+// 	stack.push(&temp)
+// 	if err == nil || err == ErrExecutionReverted {
+// 		scope.Memory.Set(retOffset.Uint64(), retSize.Uint64(), ret)
+// 	}
+
+// 	scope.Contract.RefundGas(returnGas, evm.Config.Tracer, tracing.GasChangeCallLeftOverRefunded)
+
+// 	evm.returnData = ret
+// 	return ret, nil
+// }
+
+// func opDelegateCall(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
+// 	stack := scope.Stack
+// 	// Pop gas. The actual gas is in evm.callGasTemp.
+// 	// We use it as a temporary value
+// 	temp := stack.pop()
+// 	gas := evm.callGasTemp
+// 	// Pop other call parameters.
+// 	addr, inOffset, inSize, retOffset, retSize := stack.pop(), stack.pop(), stack.pop(), stack.pop(), stack.pop()
+// 	toAddr := common.Address(addr.Bytes20())
+// 	// Get arguments from the memory.
+// 	args := scope.Memory.GetPtr(inOffset.Uint64(), inSize.Uint64())
+
+// 	ret, returnGas, err := evm.DelegateCall(scope.Contract.Caller(), scope.Contract.Address(), toAddr, args, gas, scope.Contract.value)
+// 	if err != nil {
+// 		temp.Clear()
+// 	} else {
+// 		temp.SetOne()
+// 	}
+// 	stack.push(&temp)
+// 	if err == nil || err == ErrExecutionReverted {
+// 		scope.Memory.Set(retOffset.Uint64(), retSize.Uint64(), ret)
+// 	}
+
+// 	scope.Contract.RefundGas(returnGas, evm.Config.Tracer, tracing.GasChangeCallLeftOverRefunded)
+
+// 	evm.returnData = ret
+// 	return ret, nil
+// }
+
+// func opStaticCall(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
+// 	// Pop gas. The actual gas is in evm.callGasTemp.
+// 	stack := scope.Stack
+// 	// We use it as a temporary value
+// 	temp := stack.pop()
+// 	gas := evm.callGasTemp
+// 	// Pop other call parameters.
+// 	addr, inOffset, inSize, retOffset, retSize := stack.pop(), stack.pop(), stack.pop(), stack.pop(), stack.pop()
+// 	toAddr := common.Address(addr.Bytes20())
+// 	// Get arguments from the memory.
+// 	args := scope.Memory.GetPtr(inOffset.Uint64(), inSize.Uint64())
+
+// 	ret, returnGas, err := evm.StaticCall(scope.Contract.Address(), toAddr, args, gas)
+// 	if err != nil {
+// 		temp.Clear()
+// 	} else {
+// 		temp.SetOne()
+// 	}
+// 	stack.push(&temp)
+// 	if err == nil || err == ErrExecutionReverted {
+// 		scope.Memory.Set(retOffset.Uint64(), retSize.Uint64(), ret)
+// 	}
+
+// 	scope.Contract.RefundGas(returnGas, evm.Config.Tracer, tracing.GasChangeCallLeftOverRefunded)
+
+// 	evm.returnData = ret
+// 	return ret, nil
+// }
+
+// func opReturn(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
+// 	offset, size := scope.Stack.pop(), scope.Stack.pop()
+// 	ret := scope.Memory.GetCopy(offset.Uint64(), size.Uint64())
+
+// 	return ret, errStopToken
+// }
+
+// func opRevert(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
+// 	offset, size := scope.Stack.pop(), scope.Stack.pop()
+// 	ret := scope.Memory.GetCopy(offset.Uint64(), size.Uint64())
+
+// 	evm.returnData = ret
+// 	return ret, ErrExecutionReverted
+// }
+
+// func opUndefined(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
+// 	return nil, &ErrInvalidOpCode{opcode: OpCode(scope.Contract.Code[*pc])}
+// }
+
+// func opStop(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
+// 	return nil, errStopToken
+// }
+
+// func opSelfdestruct(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
+// 	if evm.readOnly {
+// 		return nil, ErrWriteProtection
+// 	}
+// 	beneficiary := scope.Stack.pop()
+// 	balance := evm.StateDB.GetBalance(scope.Contract.Address())
+// 	evm.StateDB.AddBalance(beneficiary.Bytes20(), balance, tracing.BalanceIncreaseSelfdestruct)
+// 	evm.StateDB.SelfDestruct(scope.Contract.Address())
+// 	if tracer := evm.Config.Tracer; tracer != nil {
+// 		if tracer.OnEnter != nil {
+// 			tracer.OnEnter(evm.depth, byte(SELFDESTRUCT), scope.Contract.Address(), beneficiary.Bytes20(), []byte{}, 0, balance.ToBig())
+// 		}
+// 		if tracer.OnExit != nil {
+// 			tracer.OnExit(evm.depth, []byte{}, 0, nil, false)
+// 		}
+// 	}
+// 	return nil, errStopToken
+// }
+
+// func opSelfdestruct6780(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
+// 	if evm.readOnly {
+// 		return nil, ErrWriteProtection
+// 	}
+// 	beneficiary := scope.Stack.pop()
+// 	balance := evm.StateDB.GetBalance(scope.Contract.Address())
+// 	evm.StateDB.SubBalance(scope.Contract.Address(), balance, tracing.BalanceDecreaseSelfdestruct)
+// 	evm.StateDB.AddBalance(beneficiary.Bytes20(), balance, tracing.BalanceIncreaseSelfdestruct)
+// 	evm.StateDB.SelfDestruct6780(scope.Contract.Address())
+// 	if tracer := evm.Config.Tracer; tracer != nil {
+// 		if tracer.OnEnter != nil {
+// 			tracer.OnEnter(evm.depth, byte(SELFDESTRUCT), scope.Contract.Address(), beneficiary.Bytes20(), []byte{}, 0, balance.ToBig())
+// 		}
+// 		if tracer.OnExit != nil {
+// 			tracer.OnExit(evm.depth, []byte{}, 0, nil, false)
+// 		}
+// 	}
+// 	return nil, errStopToken
+// }
+
+// // following functions are used by the instruction jump  table
+
+// // make log instruction function
+// func makeLog(size int) executionFunc {
+// 	return func(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
+// 		if evm.readOnly {
+// 			return nil, ErrWriteProtection
+// 		}
+// 		topics := make([]common.Hash, size)
+// 		stack := scope.Stack
+// 		mStart, mSize := stack.pop(), stack.pop()
+// 		for i := 0; i < size; i++ {
+// 			addr := stack.pop()
+// 			topics[i] = addr.Bytes32()
+// 		}
+
+// 		d := scope.Memory.GetCopy(mStart.Uint64(), mSize.Uint64())
+// 		evm.StateDB.AddLog(&types.Log{
+// 			Address: scope.Contract.Address(),
+// 			Topics:  topics,
+// 			Data:    d,
+// 			// This is a non-consensus field, but assigned here because
+// 			// core/state doesn't know the current block number.
+// 			BlockNumber: evm.Context.BlockNumber.Uint64(),
+// 		})
+
+// 		return nil, nil
+// 	}
+// }
+
+// // opPush1 is a specialized version of pushN
+// func opPush1(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
+// 	var (
+// 		codeLen = uint64(len(scope.Contract.Code))
+// 		integer = new(uint256.Int)
+// 	)
+// 	*pc += 1
+// 	if *pc < codeLen {
+// 		scope.Stack.push(integer.SetUint64(uint64(scope.Contract.Code[*pc])))
+// 	} else {
+// 		scope.Stack.push(integer.Clear())
+// 	}
+// 	return nil, nil
+// }
+
+// // opPush2 is a specialized version of pushN
+// func opPush2(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
+// 	var (
+// 		codeLen = uint64(len(scope.Contract.Code))
+// 		integer = new(uint256.Int)
+// 	)
+// 	if *pc+2 < codeLen {
+// 		scope.Stack.push(integer.SetBytes2(scope.Contract.Code[*pc+1 : *pc+3]))
+// 	} else if *pc+1 < codeLen {
+// 		scope.Stack.push(integer.SetUint64(uint64(scope.Contract.Code[*pc+1]) << 8))
+// 	} else {
+// 		scope.Stack.push(integer.Clear())
+// 	}
+// 	*pc += 2
+// 	return nil, nil
+// }
+
+// // make push instruction function
+// func makePush(size uint64, pushByteSize int) executionFunc {
+// 	return func(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
+// 		var (
+// 			codeLen = len(scope.Contract.Code)
+// 			start   = min(codeLen, int(*pc+1))
+// 			end     = min(codeLen, start+pushByteSize)
+// 		)
+// 		a := new(uint256.Int).SetBytes(scope.Contract.Code[start:end])
+
+// 		// Missing bytes: pushByteSize - len(pushData)
+// 		if missing := pushByteSize - (end - start); missing > 0 {
+// 			a.Lsh(a, uint(8*missing))
+// 		}
+// 		scope.Stack.push(a)
+// 		*pc += size
+// 		return nil, nil
+// 	}
+// }
+
+// // make dup instruction function
+// func makeDup(size int) executionFunc {
+// 	return func(pc *uint64, evm *EVM, scope *ScopeContext) ([]byte, error) {
+// 		scope.Stack.dup(size)
+// 		return nil, nil
+// 	}
+// }

--- a/compiler/jump_table.go
+++ b/compiler/jump_table.go
@@ -23,6 +23,8 @@ import (
 )
 
 type (
+	HostFunc func(pc *uint64, e *EVM, scope *ScopeContext) ([]byte, error)
+
 	// executionFunc func(pc *uint64, interpreter *EVMInterpreter, callContext *ScopeContext) ([]byte, error)
 	gasFunc func(*EVM, *Contract, *Stack, *Memory, uint64) (uint64, error) // last parameter is the requested memory size as a uint64
 	// memorySizeFunc returns the required size, and whether the operation overflowed a uint64
@@ -325,13 +327,13 @@ func newFrontierInstructionSet() JumpTable {
 			diffDiff:    diffStack(2, 1),
 		},
 		ADDMOD: {
-			execute:     hostOpAddMod,
+			execute:     opAddmod,
 			constantGas: GasMidStep,
 			minStack:    minStack(3, 1),
 			diffDiff:    diffStack(3, 1),
 		},
 		MULMOD: {
-			execute:     hostOpMulMod,
+			execute:     opMulmod,
 			constantGas: GasMidStep,
 			minStack:    minStack(3, 1),
 			diffDiff:    diffStack(3, 1),
@@ -423,7 +425,7 @@ func newFrontierInstructionSet() JumpTable {
 			// // memorySize:  memoryKeccak256,
 		},
 		ADDRESS: {
-			execute:     hostOpAddress,
+			execute:     opAddress,
 			constantGas: GasQuickStep,
 			minStack:    minStack(0, 1),
 			diffDiff:    diffStack(0, 1),
@@ -435,13 +437,13 @@ func newFrontierInstructionSet() JumpTable {
 			diffDiff:    diffStack(1, 1),
 		},
 		ORIGIN: {
-			execute:     hostOpOrigin,
+			execute:     opOrigin,
 			constantGas: GasQuickStep,
 			minStack:    minStack(0, 1),
 			diffDiff:    diffStack(0, 1),
 		},
 		CALLER: {
-			execute:     hostOpCaller,
+			execute:     opCaller,
 			constantGas: GasQuickStep,
 			minStack:    minStack(0, 1),
 			diffDiff:    diffStack(0, 1),
@@ -513,7 +515,7 @@ func newFrontierInstructionSet() JumpTable {
 			diffDiff:    diffStack(1, 1),
 		},
 		COINBASE: {
-			execute:     hostOpCoinbase,
+			execute:     opCoinbase,
 			constantGas: GasQuickStep,
 			minStack:    minStack(0, 1),
 			diffDiff:    diffStack(0, 1),
@@ -549,7 +551,7 @@ func newFrontierInstructionSet() JumpTable {
 			diffDiff:    diffStack(1, 0),
 		},
 		MLOAD: {
-			execute:     hostOpMload,
+			execute:     opMload,
 			constantGas: GasFastestStep,
 			dynamicGas:  gasMLoad,
 			minStack:    minStack(1, 1),
@@ -557,7 +559,7 @@ func newFrontierInstructionSet() JumpTable {
 			memorySize:  memoryMLoad,
 		},
 		MSTORE: {
-			execute:     hostOpMstore,
+			execute:     opMstore,
 			constantGas: GasFastestStep,
 			dynamicGas:  gasMStore,
 			minStack:    minStack(2, 0),
@@ -565,7 +567,7 @@ func newFrontierInstructionSet() JumpTable {
 			memorySize:  memoryMStore,
 		},
 		MSTORE8: {
-			execute:     hostOpMstore8,
+			execute:     opMstore8,
 			constantGas: GasFastestStep,
 			dynamicGas:  gasMStore8,
 			memorySize:  memoryMStore8,
@@ -573,13 +575,13 @@ func newFrontierInstructionSet() JumpTable {
 			diffDiff:    diffStack(2, 0),
 		},
 		SLOAD: {
-			execute:     hostOpSload,
+			execute:     opSload,
 			constantGas: params.SloadGasFrontier,
 			minStack:    minStack(1, 1),
 			diffDiff:    diffStack(1, 1),
 		},
 		SSTORE: {
-			execute:    hostOpSstore,
+			execute:    opSstore,
 			dynamicGas: gasSStore,
 			minStack:   minStack(2, 0),
 			diffDiff:   diffStack(2, 0),

--- a/compiler/opcodes_test.go
+++ b/compiler/opcodes_test.go
@@ -107,7 +107,7 @@ func runOpcodeTest(t *testing.T, testCase OpcodeTestCase) {
 		}
 		return
 	} else if result.Status != ExecutionSuccess {
-		t.Errorf("Expected success but got none")
+		t.Errorf("Expected success but got error %v", result.Status)
 	}
 
 	if err != nil {


### PR DESCRIPTION
Solve #52 , the benefits are
- reuse existing Geth instruction functions - the change is almost none
- avoid memory copy from compiled code to uint256 in Go

cons:
- the machine must be little-endian