### PR TITLE
add PUSH0 and add fib/fractoral benchmark with calldata

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -154,8 +154,8 @@ func (c *EVMCompiler) ParseBytecode(bytecode []byte) ([]EVMInstruction, error) {
 			PC:     pc,
 		}
 
-		if opcode >= PUSH1 && opcode <= PUSH32 {
-			dataSize := int(opcode - PUSH1 + 1)
+		if opcode >= PUSH0 && opcode <= PUSH32 {
+			dataSize := int(opcode - PUSH0)
 			if pc+uint64(dataSize) >= uint64(len(bytecode)) {
 				return nil, fmt.Errorf("invalid PUSH instruction at PC %d", pc)
 			}

--- a/compiler/compiler_static.go
+++ b/compiler/compiler_static.go
@@ -74,11 +74,8 @@ func (c *EVMCompiler) CompileBytecodeStatic(bytecode []byte, opts *EVMCompilatio
 	c.builder.CreateStore(llvm.ConstInt(c.ctx.Int64Type(), 0, false), stackPtr)
 
 	// Initialize gasPtr tracking
-	var gasPtr llvm.Value
-	if !opts.DisableGas {
-		gasPtr = c.builder.CreateAlloca(c.ctx.Int64Type(), "gas_used")
-		c.builder.CreateStore(gasLimitParam, gasPtr)
-	}
+	gasPtr := c.builder.CreateAlloca(c.ctx.Int64Type(), "gas_used")
+	c.builder.CreateStore(gasLimitParam, gasPtr)
 
 	// Create out-of-gas block
 	errorBlock := llvm.AddBasicBlock(execFunc, "error")
@@ -528,7 +525,7 @@ func (c *EVMCompiler) compileInstructionStatic(instr EVMInstruction, execInst, s
 		c.builder.CreateBr(exitBlock)
 
 	default:
-		if instr.Opcode >= PUSH1 && instr.Opcode <= PUSH32 {
+		if instr.Opcode >= PUSH0 && instr.Opcode <= PUSH32 {
 			c.compilePushStatic(instr, stack, stackPtr, nextBlock)
 		} else if instr.Opcode >= DUP1 && instr.Opcode <= DUP16 {
 			c.compileDupStatic(instr, stack, stackPtr, nextBlock)


### PR DESCRIPTION
- use AllDevChainProtocolChanges so that we can have the latest EIPs
- add PUSH0, which was introduced in Shanghai
- benchmark with calldata

```
BenchmarkEVMExecuteFibCalldata/NoGas                1148           1041364 ns/op
BenchmarkEVMExecuteFibCalldata/Gas                   975           1230004 ns/op
BenchmarkEVMExecuteFibCalldata/Section              1268            944746 ns/op
BenchmarkEVMExecuteFibCalldata/Interp                100          11977784 ns/op
BenchmarkEVMExecuteFactorial/NoGas                  1338            898477 ns/op
BenchmarkEVMExecuteFactorial/Gas                     673           1781608 ns/op
BenchmarkEVMExecuteFactorial/Section                1303            918149 ns/op
BenchmarkEVMExecuteFactorial/Interp                   94          12589878 ns/op
```
where the performance becomes ~12x.