### PR TITLE
add some edge cases

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -103,7 +103,7 @@ const (
 	ExecutionStackOverflow
 	ExecutionStackUnderflow
 	ExecutionInvalidJumpDest
-	ExecutionUnsupportedOpcode
+	ExecutionInvalidOpcode
 	ExecutionUnknown
 )
 
@@ -159,11 +159,13 @@ func (c *EVMCompiler) ParseBytecode(bytecode []byte) ([]EVMInstruction, error) {
 
 		if opcode >= PUSH0 && opcode <= PUSH32 {
 			dataSize := int(opcode - PUSH0)
-			if pc+uint64(dataSize) >= uint64(len(bytecode)) {
-				return nil, fmt.Errorf("invalid PUSH instruction at PC %d", pc)
-			}
 			instr.Data = make([]byte, dataSize)
-			copy(instr.Data, bytecode[pc+1:pc+1+uint64(dataSize)])
+			if pc+uint64(dataSize) >= uint64(len(bytecode)) {
+				// pad zeros
+				copy(instr.Data, bytecode[pc+1:])
+			} else {
+				copy(instr.Data, bytecode[pc+1:pc+1+uint64(dataSize)])
+			}
 			pc += uint64(dataSize)
 		}
 		instructions = append(instructions, instr)

--- a/compiler/opcodes_test.go
+++ b/compiler/opcodes_test.go
@@ -1654,7 +1654,30 @@ func TestOpcodeErrorConditions(t *testing.T) {
 			bytecode: []byte{
 				0xBB,
 			},
-			expectedStatus: getExpectedStatus(ExecutionUnsupportedOpcode),
+			expectedStatus: getExpectedStatus(ExecutionInvalidOpcode),
+		},
+		{
+			name: "PUSH1_EOF",
+			bytecode: []byte{
+				0x60, // PUSH1
+			},
+			expectedStack: [][32]byte{uint64ToBytes32(0)},
+			expectedGas:   3,
+		},
+		{
+			name: "PUSH2_EOF",
+			bytecode: []byte{
+				0x61, 0x11, // PUSH2 0x1100
+			},
+			expectedStack: [][32]byte{uint64ToBytes32(0x1100)},
+			expectedGas:   3,
+		},
+		{
+			name: "INVALID",
+			bytecode: []byte{
+				0xFE, // INVALID
+			},
+			expectedStatus: getExpectedStatus(ExecutionInvalidOpcode),
 		},
 	}
 


### PR DESCRIPTION
- add 0xFE opcode support (invalid) and change UnsupportedOpcde to InvalidOpcode error
- add handling of PUSHx without sufficient data (EOF) by padding bytes
- charge gas correctly if the contract does not end with STOP